### PR TITLE
Fix SEGV

### DIFF
--- a/gitlab/url_parser.go
+++ b/gitlab/url_parser.go
@@ -33,7 +33,11 @@ func NewGitlabURLParser(params *URLParserParams) (*URLParser, error) {
 		isDebugLogging: params.IsDebugLogging,
 	}
 
-	client, err := gitlab.NewClient(params.PrivateToken, gitlab.WithHTTPClient(params.HTTPClient), gitlab.WithBaseURL(params.APIEndpoint))
+	options := []gitlab.ClientOptionFunc{gitlab.WithBaseURL(params.APIEndpoint)}
+	if params.HTTPClient != nil {
+		options = append(options, gitlab.WithHTTPClient(params.HTTPClient))
+	}
+	client, err := gitlab.NewClient(params.PrivateToken, options...)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
Apr 04 23:51:38 gitpanda app/web.1: panic: runtime error: invalid memory address or nil pointer dereference
Apr 04 23:51:38 gitpanda app/web.1: [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x699b32]
Apr 04 23:51:38 gitpanda app/web.1:
Apr 04 23:51:38 gitpanda app/web.1: goroutine 23 [running]:
Apr 04 23:51:38 gitpanda app/web.1: net/http.(*Client).deadline(0x0, 0xc000232348, 0xffffffffffff, 0xf8)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go1.12.17/go/src/net/http/client.go:187 +0x22
Apr 04 23:51:38 gitpanda app/web.1: net/http.(*Client).do(0x0, 0xc00024a400, 0x0, 0x0, 0x0)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go1.12.17/go/src/net/http/client.go:527 +0xab
Apr 04 23:51:38 gitpanda app/web.1: net/http.(*Client).Do(...)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go1.12.17/go/src/net/http/client.go:509
Apr 04 23:51:38 gitpanda app/web.1: github.com/xanzy/go-gitlab.(*Client).configureLimiter(0xc000276000, 0x0, 0x0)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go-path/pkg/mod/github.com/xanzy/go-gitlab@v0.31.0/gitlab.go:686 +0xf7
Apr 04 23:51:38 gitpanda app/web.1: github.com/xanzy/go-gitlab.(*Client).Do.func1()
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go-path/pkg/mod/github.com/xanzy/go-gitlab@v0.31.0/gitlab.go:875 +0x2a
Apr 04 23:51:38 gitpanda app/web.1: sync.(*Once).Do(0xc000276014, 0xc000065e00)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go1.12.17/go/src/sync/once.go:44 +0xb3
Apr 04 23:51:38 gitpanda app/web.1: github.com/xanzy/go-gitlab.(*Client).Do(0xc000276000, 0xc00012a490, 0xc6ed60, 0xc0002646c0, 0x0, 0x0, 0x0)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go-path/pkg/mod/github.com/xanzy/go-gitlab@v0.31.0/gitlab.go:875 +0x89
Apr 04 23:51:38 gitpanda app/web.1: github.com/xanzy/go-gitlab.(*ProjectsService).GetProject(0xc000232268, 0xc1f740, 0xc00012a440, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc000238480, 0xc00013a900, ...)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go-path/pkg/mod/github.com/xanzy/go-gitlab@v0.31.0/projects.go:374 +0x1c9
Apr 04 23:51:38 gitpanda app/web.1: github.com/sue445/gitpanda/gitlab.(*mergeRequestFetcher).fetchPath.func2(0x8, 0xde36d8)
Apr 04 23:51:38 gitpanda app/web.1: 	/tmp/build_96089d21565a9a9b79a9ac6b5c95c240/gitlab/merge_request_fetcher.go:83 +0xd2
Apr 04 23:51:38 gitpanda app/web.1: golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0001268d0, 0xc000126900)
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go-path/pkg/mod/golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4/errgroup/errgroup.go:57 +0x57
Apr 04 23:51:38 gitpanda app/web.1: created by golang.org/x/sync/errgroup.(*Group).Go
Apr 04 23:51:38 gitpanda app/web.1: 	/app/tmp/cache/go-path/pkg/mod/golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4/errgroup/errgroup.go:54 +0x66
```