### PR TITLE
Support blob link without line hash

### DIFF
--- a/gitlab/url_parser_test.go
+++ b/gitlab/url_parser_test.go
@@ -571,6 +571,24 @@ func TestGitlabUrlParser_FetchURL(t *testing.T) {
 			},
 		},
 		{
+			name: "Blob URL (without line hash)",
+			args: args{
+				url: "http://example.com/diaspora/diaspora-project-site/blob/master/gitlabci-templates/continuous_bundle_update.yml",
+			},
+			want: &Page{
+				Title:                  "gitlabci-templates/continuous_bundle_update.yml",
+				Description:            "```\ncontinuous_bundle_update:\n  image: ruby\n\n  variables:\n    CACHE_VERSION: \"v1\"\n    GIT_EMAIL:     \"gitlabci@example.com\"\n    GIT_USER:      \"GitLab CI\"\n    LABELS:        \"bundle update\"\n    OPTIONS:       \"\"\n\n  cache:\n    key: \"$CACHE_VERSION-$CI_BUILD_NAME\"\n    paths:\n      - vendor/bundle/\n\n  script:\n    - bundle install --path vendor/bundle --clean\n    - gem install --no-doc gitlabci-bundle-update-mr\n    - gitlabci-bundle-update-mr --user=\"$GIT_USER\" --email=\"$GIT_EMAIL\" --labels=\"$LABELS\" $OPTIONS\n\n  only:\n    - schedules\n\n```",
+				AuthorName:             "",
+				AuthorAvatarURL:        "",
+				AvatarURL:              "http://example.com/uploads/project/avatar/3/uploads/avatar.png",
+				CanTruncateDescription: false,
+				FooterTitle:            "diaspora/diaspora-project-site",
+				FooterURL:              "http://example.com/diaspora/diaspora-project-site",
+				FooterTime:             nil,
+				Color:                  "",
+			},
+		},
+		{
 			name: "Job URL",
 			args: args{
 				url: "http://example.com/diaspora/diaspora-project-site/jobs/8",


### PR DESCRIPTION
Thank you for creating this great tool! 

Currently, gitpanda does not support a blob link without Line Hash.
But GitHub integration on Slack supports a link without Line Hash like this.
![image](https://user-images.githubusercontent.com/8841470/83881323-683f0d00-a77b-11ea-8610-07033949b274.png)

So I think it would be great if gitpanda can support blob link without line hash like GitHub!