### PR TITLE
Support snippet routes including `/-/` for GitLab 13.3.0+

### DIFF
--- a/gitlab/snippet_fetcher.go
+++ b/gitlab/snippet_fetcher.go
@@ -14,7 +14,7 @@ type snippetFetcher struct {
 }
 
 func (f *snippetFetcher) fetchPath(path string, client *gitlab.Client, isDebugLogging bool) (*Page, error) {
-	re := regexp.MustCompile("^snippets/(\\d+)")
+	re := regexp.MustCompile("^(?:-/)?snippets/(\\d+)")
 	matched := re.FindStringSubmatch(path)
 
 	if matched == nil {

--- a/gitlab/url_parser_test.go
+++ b/gitlab/url_parser_test.go
@@ -773,6 +773,24 @@ func TestGitlabUrlParser_FetchURL(t *testing.T) {
 				Color:                  "",
 			},
 		},
+		{
+			name: "Snippet URL (including /-/)",
+			args: args{
+				url: "http://example.com/-/snippets/3",
+			},
+			want: &Page{
+				Title:                  "add.rb",
+				Description:            "```\nputs 'Hello'\n```",
+				AuthorName:             "John Smith",
+				AuthorAvatarURL:        "",
+				AvatarURL:              "",
+				CanTruncateDescription: false,
+				FooterTitle:            "",
+				FooterURL:              "",
+				FooterTime:             tp(time.Date(2012, 6, 28, 10, 52, 4, 0, time.UTC)),
+				Color:                  "",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
c.f. 

* https://gitlab.com/gitlab-org/gitlab/-/blob/master/CHANGELOG.md#1330-2020-08-22
* https://gitlab.com/gitlab-org/gitlab/-/merge_requests/36091