### PR TITLE
Fixed failure to send error to Sentry when not AWS Lambda

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func normalHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Printf("[ERROR] body=%s, response=%s, error=%v\n", body, response, err)
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
-			return
+			panic(err)
 		}
 
 		w.Write([]byte(response))

--- a/sentry_client.go
+++ b/sentry_client.go
@@ -31,7 +31,9 @@ func NewSentryClient(dsn string, debug bool) (*SentryClient, Close, error) {
 		}
 	}
 
-	sentryHandler := sentryhttp.New(sentryhttp.Options{})
+	sentryHandler := sentryhttp.New(sentryhttp.Options{
+		Repanic: true,
+	})
 
 	return &SentryClient{dsn: dsn, handler: sentryHandler}, releaseSentry, nil
 }


### PR DESCRIPTION
gitpanda on AWS Lambda is no problem, but Heroku and GKE are wrong...