### PR TITLE
Migrate to ahmadnassri/action-dependabot-auto-merge

### DIFF
--- a/.github/dependabot-auto-merge.yml
+++ b/.github/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+- match:
+    dependency_type: "development"
+    update_type: "all"
+- match:
+    dependency_type: "production"
+    update_type: "semver:patch"
+- match:
+    dependency_name: "github.com/stretchr/testify"
+    update_type: "all"
+- match:
+    dependency_name: "github.com/jarcoal/httpmock"
+    update_type: "all"
+- match:
+    dependency_name: "github.com/aws/aws-lambda-go"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "github.com/aws/aws-sdk-go"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "github.com/xanzy/go-gitlab"
+    update_type: "semver:minor"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,9 +2,7 @@ name: dependabot-auto-merge
 
 on:
   pull_request_target:
-permissions:
-  pull-requests: write
-  contents: write
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
@@ -12,29 +10,12 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
-      - name: Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
 
-      - name: Enable auto-merge for Dependabot PRs
-        if:
-          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'github.com/stretchr/testify') ||
-          contains(steps.dependabot-metadata.outputs.dependency-names, 'github.com/jarcoal/httpmock') ||
-          (
-            steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' &&
-            (
-              contains(steps.dependabot-metadata.outputs.dependency-names, 'github.com/aws/aws-lambda-go') ||
-              contains(steps.dependabot-metadata.outputs.dependency-names, 'github.com/aws/aws-sdk-go') ||
-              contains(steps.dependabot-metadata.outputs.dependency-names, 'github.com/xanzy/go-gitlab')
-            )
-          )
-        run: gh pr merge --auto --merge --delete-branch "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.GH_PAT_DEPENDABOT_AUTO_MERGE }}
+          config: .github/dependabot-auto-merge.yml
 
       - name: Slack Notification (not success)
         uses: lazy-actions/slatify@master


### PR DESCRIPTION
In the previous `dependabot-auto-merge`, the default `secrets.GITHUB_TOKEN` was used to merge the PR. 

But with that, GitHub Actions can't execute other Action (docker-gcp).