### PR TITLE
ignore URL parameters in blobFetcher

### DIFF
--- a/gitlab/blob_fetcher.go
+++ b/gitlab/blob_fetcher.go
@@ -33,6 +33,12 @@ func (f *blobFetcher) fetchPath(path string, client *gitlab.Client, isDebugLoggi
 		fileName = lineMatched[1]
 	}
 
+	paramsMatched := regexp.MustCompile("(.+)\\?(.+)$").FindStringSubmatch(fileName)
+
+	if paramsMatched != nil {
+		fileName = paramsMatched[1]
+	}
+
 	var eg errgroup.Group
 
 	selectedFile := ""

--- a/gitlab/url_parser_test.go
+++ b/gitlab/url_parser_test.go
@@ -586,6 +586,24 @@ func TestGitlabUrlParser_FetchURL(t *testing.T) {
 			},
 		},
 		{
+			name: "Blob URL (single line & including /-/ & conain url_params)",
+			args: args{
+				url: "http://example.com/diaspora/diaspora-project-site/-/blob/master/gitlabci-templates/continuous_bundle_update.yml?ref_type=head#L4",
+			},
+			want: &Page{
+				Title:                  "gitlabci-templates/continuous_bundle_update.yml:4",
+				Description:            "```\n  variables:\n```",
+				AuthorName:             "",
+				AuthorAvatarURL:        "",
+				AvatarURL:              "http://example.com/uploads/project/avatar/3/uploads/avatar.png",
+				CanTruncateDescription: false,
+				FooterTitle:            "diaspora/diaspora-project-site",
+				FooterURL:              "http://example.com/diaspora/diaspora-project-site",
+				FooterTime:             nil,
+				Color:                  "",
+			},
+		},
+		{
 			name: "Blob URL (multiple line)",
 			args: args{
 				url: "http://example.com/diaspora/diaspora-project-site/blob/master/gitlabci-templates/continuous_bundle_update.yml#L4-9",


### PR DESCRIPTION
GitLab has been updated to include the following URL parameters when viewing files

* `ref_type=(heads|tags)` : to view files by branch or tags
* `plain=1` : When viewing a markdown file in the `Display source` view.

Added handling to ignore URL parameters, since gitpanda fails to fetch files when URLs with URL parameters are shared.