### PR TITLE
Fix dependabot error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/sue445/gitpanda
 
 go 1.21
+toolchain go1.21.0
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d


### PR DESCRIPTION
```
go: downloading go1.21 (linux/amd64)
go: download go1.21 for linux/amd64: toolchain not available
```

https://github.com/orgs/community/discussions/65431#discussioncomment-6875620